### PR TITLE
Support .NETStandard 2.0 to support ASP.NET Core websites based on .NET 4.6.1

### DIFF
--- a/src/Localization.SqlLocalizer/Localization.SqlLocalizer.csproj
+++ b/src/Localization.SqlLocalizer/Localization.SqlLocalizer.csproj
@@ -4,7 +4,7 @@
     <Description>SQL Localizer for ASP.NET Core, dotnet</Description>
     <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>damienbod</Authors>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Localization.SqlLocalizer</PackageId>
     <PackageTags>Localization;SqlLocalizer;SQlite;Postgres;MS SQL Server;MySQL</PackageTags>
     <PackageReleaseNotes>Release Notes: Version 2.0.2
@@ -19,7 +19,7 @@ development mode, add, update item</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0" />


### PR DESCRIPTION
Is there any reason why the assembly Localization.SqlLocalizer is based on netcoreapp2.0? This leads to the fact that no ASP.NET Core projects based on the .NET 4.6.1 Framework can reference this package.

I changed the TargetFramework to .netstandard2.0 and changed the reference Microsoft.AspNetCore.All to Microsoft.AspNetCore.Localization. I runned the integration tests and it worked.

Are there any more reasons to use .netcoreapp2.0?