### PR TITLE
Added locks in order to protect against more than one thread reading/…

### DIFF
--- a/src/Localization.SqlLocalizer/DbStringLocalizer/DevelopmentSetup.cs
+++ b/src/Localization.SqlLocalizer/DbStringLocalizer/DevelopmentSetup.cs
@@ -34,8 +34,12 @@ namespace Localization.SqlLocalizer.DbStringLocalizer
                     Text = computedKey,
                     ResourceKey = resourceKey
                 };
-                _context.LocalizationRecords.Add(localizationRecord);
-                _context.SaveChanges();
+
+                lock (_context)
+                {
+                    _context.LocalizationRecords.Add(localizationRecord);
+                    _context.SaveChanges();
+                }
             }
         }
     }


### PR DESCRIPTION
…writing _context at a time.  According to EF Core devs, we should assume DbContext is not thread safe.  These changes appear to fix intermittent issues we were having with SqlLocalizer generating DbContext concurrency exceptions when the _resourceLocalizations cache is first loaded after an application/IIS restart.