### PR TITLE
View localizer now respects UsePropertyNamesOnly property.

### DIFF
--- a/src/Localization.SqlLocalizer/DbStringLocalizer/SqlStringLocalizerFactory.cs
+++ b/src/Localization.SqlLocalizer/DbStringLocalizer/SqlStringLocalizerFactory.cs
@@ -81,7 +81,7 @@ namespace Localization.SqlLocalizer.DbStringLocalizer
             }
 
             var sqlStringLocalizer = new SqlStringLocalizer(GetAllFromDatabaseForResource(resourceKey), _developmentSetup, resourceKey, returnOnlyKeyIfNotFound, createNewRecordWhenLocalisedStringDoesNotExist);
-            return _resourceLocalizations.GetOrAdd(baseName + location, sqlStringLocalizer);
+            return _resourceLocalizations.GetOrAdd(resourceKey, sqlStringLocalizer);
         }
 
         public void ResetCache()

--- a/src/Localization.SqlLocalizer/DbStringLocalizer/SqlStringLocalizerFactory.cs
+++ b/src/Localization.SqlLocalizer/DbStringLocalizer/SqlStringLocalizerFactory.cs
@@ -68,12 +68,19 @@ namespace Localization.SqlLocalizer.DbStringLocalizer
         {
             var returnOnlyKeyIfNotFound = _options.Value.ReturnOnlyKeyIfNotFound;
             var createNewRecordWhenLocalisedStringDoesNotExist = _options.Value.CreateNewRecordWhenLocalisedStringDoesNotExist;
-            if (_resourceLocalizations.Keys.Contains(baseName + location))
+
+            var resourceKey = baseName + location;
+            if (_options.Value.UseOnlyPropertyNames)
             {
-                return _resourceLocalizations[baseName + location];
+                resourceKey = Global;
             }
 
-            var sqlStringLocalizer = new SqlStringLocalizer(GetAllFromDatabaseForResource(baseName + location), _developmentSetup, baseName + location, returnOnlyKeyIfNotFound, createNewRecordWhenLocalisedStringDoesNotExist);
+            if (_resourceLocalizations.Keys.Contains(resourceKey))
+            {
+                return _resourceLocalizations[resourceKey];
+            }
+
+            var sqlStringLocalizer = new SqlStringLocalizer(GetAllFromDatabaseForResource(resourceKey), _developmentSetup, resourceKey, returnOnlyKeyIfNotFound, createNewRecordWhenLocalisedStringDoesNotExist);
             return _resourceLocalizations.GetOrAdd(baseName + location, sqlStringLocalizer);
         }
 


### PR DESCRIPTION
IViewLocalizer used in views directly invokes Create method with baseName and location parameters, thus bypassing UsePropertyNamesOnly since it's only set in the Create(Type) method. It now correctly places everything under global if set to true.