### PR TITLE
Fixed a performance issue for update/add that occurs due some gymnast…

### DIFF
--- a/src/Localization.SqlLocalizer/DbStringLocalizer/LocalizationModelContext.cs
+++ b/src/Localization.SqlLocalizer/DbStringLocalizer/LocalizationModelContext.cs
@@ -60,10 +60,8 @@ namespace Localization.SqlLocalizer.DbStringLocalizer
         public void DetachAllEntities()
         {
             var changedEntriesCopy = ChangeTracker.Entries().ToList();
-            foreach (var entity in changedEntriesCopy)
-            {
-                Entry(entity.Entity).State = EntityState.Detached;
-            }
+            foreach (var entry in changedEntriesCopy)
+                entry.State = EntityState.Detached;
         }
     }
 }


### PR DESCRIPTION
…ics within the DetachAllEntities method

I caught this because in a test app of mine, cycling through 1000 items and marking as Detached took approx 6000ms with the existing code. About 15ms with the new :) 

Would be glad if you could deploy a new nuget package with the fix :)

According to: https://stackoverflow.com/a/33901817/3313177
