### PR TITLE
Add app support for Entity Framework 5.0

### DIFF
--- a/src/Localization.SqlLocalizer/Localization.SqlLocalizer.csproj
+++ b/src/Localization.SqlLocalizer/Localization.SqlLocalizer.csproj
@@ -29,9 +29,9 @@
   
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.0.0,5.0.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[3.0.0,5.0.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.0.0,5.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[3.0.0,6.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="[3.0.0,6.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[3.0.0,6.0.0)" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">


### PR DESCRIPTION
The .NET Core App target framework (seemingly arbitrarily) caps Entity Framework to 4.0, causing dependency issues in our project because we're using EF 5.0.  Adding 6.0 support incurs no compatibility issues in the current code, and the only reason I could see why only the .Net Framework 5.0 build target supports it was the potential use of a 5.0 utility method (https://github.com/damienbod/AspNetCoreLocalization/pull/79#issuecomment-726301644) but that method call not added.