### PR TITLE
Changes for (1) case insensitive searches and (2) falling back to parent record if not found

### DIFF
--- a/src/Localization.SqlLocalizer/DbStringLocalizer/SqlStringLocalizer.cs
+++ b/src/Localization.SqlLocalizer/DbStringLocalizer/SqlStringLocalizer.cs
@@ -57,16 +57,18 @@ namespace Localization.SqlLocalizer.DbStringLocalizer
         {
 
 #if NET451
-            var culture = System.Threading.Thread.CurrentThread.CurrentCulture.ToString();
+            var culture = System.Threading.Thread.CurrentThread.CurrentCulture;
 #elif NET46
-            var culture = System.Threading.Thread.CurrentThread.CurrentCulture.ToString();
+            var culture = System.Threading.Thread.CurrentThread.CurrentCulture;
 #else
-            var culture = CultureInfo.CurrentCulture.ToString();
+            var culture = CultureInfo.CurrentCulture;
 #endif
+
             string computedKey = $"{key}.{culture}";
+            string parentComputedKey = $"{key}.{culture.Parent.TwoLetterISOLanguageName}";
 
             string result;
-            if (_localizations.TryGetValue(computedKey, out result))
+            if (_localizations.TryGetValue(computedKey, out result) || _localizations.TryGetValue(parentComputedKey, out result))
             {
                 notSucceed = false;
                 return result;
@@ -76,7 +78,7 @@ namespace Localization.SqlLocalizer.DbStringLocalizer
                 notSucceed = true;
                 if (_createNewRecordWhenLocalisedStringDoesNotExist)
                 {
-                    _developmentSetup.AddNewLocalizedItem(key, culture, _resourceKey);
+                    _developmentSetup.AddNewLocalizedItem(key, culture.ToString(), _resourceKey);
                     _localizations.Add(computedKey, computedKey);
                     return computedKey;
                 }
@@ -89,7 +91,7 @@ namespace Localization.SqlLocalizer.DbStringLocalizer
             }
         }
 
-        
+
 
     }
 }

--- a/src/Localization.SqlLocalizer/DbStringLocalizer/SqlStringLocalizerFactory.cs
+++ b/src/Localization.SqlLocalizer/DbStringLocalizer/SqlStringLocalizerFactory.cs
@@ -110,7 +110,7 @@ namespace Localization.SqlLocalizer.DbStringLocalizer
             lock (_context)
             {
                 return _context.LocalizationRecords.Where(data => data.ResourceKey == resourceKey)
-                    .ToDictionary(kvp => (kvp.Key + "." + kvp.LocalizationCulture), kvp => kvp.Text);
+                    .ToDictionary(kvp => (kvp.Key + "." + kvp.LocalizationCulture), kvp => kvp.Text, StringComparer.OrdinalIgnoreCase);
             }
         }
 


### PR DESCRIPTION
This library is very helpful. Thank you!

However, there are two enhancements that I think others could benefit from. 

First, I would like to make it so that matching LocalizationCulture is case insensitive. If a person managing localization data uses “en-us” instead of “en-US” for a record, it will not be found because the search today is case sensitive. I would like to change it to make it case insensitive.

Second, I would like to enhance fallback behavior so that if there is no "en-US" record in the table but there is "en", it will return "en" instead if not found. This change could further be enhanced by adding a setting to turn on/off.